### PR TITLE
underline resource-text on hover

### DIFF
--- a/client/sass/_MapRender.sass
+++ b/client/sass/_MapRender.sass
@@ -75,7 +75,7 @@
 
   &:hover .resource-text
     color: $azure-radiance
-    font-weight: bold
+    text-decoration: underline
 
   .category > img
     display: flex


### PR DESCRIPTION
Bolding the text on hover would result in situations where it would jump around due to spacing changes.

### Normal State

<img width="256" alt="screen shot 2017-12-12 at 12 53 17 am" src="https://user-images.githubusercontent.com/81055/33842931-f169619a-ded6-11e7-9085-b272ca9c21a9.png">

### Hover State (Current)

<img width="256" alt="screen shot 2017-12-12 at 12 53 20 am" src="https://user-images.githubusercontent.com/81055/33842930-f12d2202-ded6-11e7-9082-6f9573ff266f.png">

### Hover State (Suggested)

<img width="317" alt="screen shot 2017-12-12 at 12 56 01 am" src="https://user-images.githubusercontent.com/81055/33843074-4a6bc40e-ded7-11e7-97d9-b38a96b69fec.png">
