### PR TITLE
Fix typo probabiliy → probability

### DIFF
--- a/api/topics.json
+++ b/api/topics.json
@@ -726,7 +726,7 @@
     {"mapID":1079,"key":"bayesian machine learning","title":"learn anything - mathematics - statistics - bayesian statistics - bayesian machine learning"},
     {"mapID":289,"key":"LLVM compiler infrastructure","title":"learn anything - computer science - compilers - llvm"},
     {"mapID":1064,"key":"Banach-Tarski paradox","title":"learn anything - mathematics - set theory - banach tarski paradox"},
-    {"mapID":1108,"key":"probabiliy theory","title":"learn anything - mathematics - statistics - probability theory"},
+    {"mapID":1108,"key":"probability theory","title":"learn anything - mathematics - statistics - probability theory"},
     {"mapID":1180,"key":"medicine","title":"learn anything - medicine"},
     {"mapID":810,"key":"branding","title":"learn anything - marketing - branding"},
     {"mapID":308,"key":"NP-hardness","title":"learn anything - computer science - computation - theory of computation - computational complexity theory - np hardness"},


### PR DESCRIPTION
### Summary

Fix typo **probabiliy** → **probability**

### Changes

- learn-anything/api/topics.json:729:25: "probabiliy" is a misspelling of "probability"