### PR TITLE
Fix typo yart to yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ To run the project:
 
 1. Clone the repo (`git clone https://github.com/learn-anything/learn-anything`)
 2. Run `yarn` (download all dependencies)
-3. Run `yart start` (start local development)
+3. Run `yarn start` (start local development)
 4. Edit the code & run it! ✨
 
 ## Opening PRs


### PR DESCRIPTION
### Summary

Fix typo **yart** to **yarn**

### Changes

- CONTRIBUTING.md

But anyway yarn is not working for me because `package.json` is not there

![Screenshot](https://user-images.githubusercontent.com/61746440/83841470-832f6400-a71e-11ea-9d82-4961ccf6a4ce.png)