### PR TITLE
Insert `Topic` with owned `Note`/`Link` resources

### DIFF
--- a/grafbase/db/dbschema/default.esdl
+++ b/grafbase/db/dbschema/default.esdl
@@ -16,18 +16,18 @@ module default {
     required content: str; # markdown
     prettyName: str; # name of topic in form of `Topic Name`
     directParent: Topic; # parent topic
-    multi notes: Note;
-    multi links: Link;
+    multi link notes := .<topic[is Note];
+    multi link links := .<topic[is Link];
     constraint exclusive on ((.name, .user)); # users can't have two topics with same name
   }
   type Note {
-    required link topic: Topic; # topic this note belongs to
+    required topic: Topic; # topic this note belongs to
     required public: bool; # if true, anyone can see the note
     required content: str;
     url: str;
   }
   type Link {
-    required link topic: Topic; # topic this note belongs to
+    required topic: Topic; # topic this note belongs to
     required public: bool; # if true, anyone can see the note
     required title: str;
     required url: str;

--- a/grafbase/db/dbschema/migrations/00001.edgeql
+++ b/grafbase/db/dbschema/migrations/00001.edgeql
@@ -1,19 +1,36 @@
-CREATE MIGRATION m17tlajhbdcmrk26aqealxrjqulez466r5oluhhh3sqwa2vlw55rrq
+CREATE MIGRATION m13rpuanc5m7plhxje37igizmscbhlh43sttf6ite373x45yrxavyq
     ONTO initial
 {
+  CREATE TYPE default::GlobalTopic {
+      CREATE REQUIRED PROPERTY name: std::str;
+      CREATE PROPERTY verified: std::bool;
+  };
   CREATE TYPE default::Link {
+      CREATE REQUIRED PROPERTY public: std::bool;
       CREATE REQUIRED PROPERTY title: std::str;
       CREATE REQUIRED PROPERTY url: std::str;
   };
-  CREATE TYPE default::Note {
+  CREATE TYPE default::Topic {
+      CREATE REQUIRED PROPERTY name: std::str;
+      CREATE LINK directParent: default::Topic;
       CREATE REQUIRED PROPERTY content: std::str;
+      CREATE PROPERTY prettyName: std::str;
+      CREATE REQUIRED PROPERTY public: std::bool;
+  };
+  ALTER TYPE default::Link {
+      CREATE REQUIRED LINK topic: default::Topic;
+  };
+  ALTER TYPE default::Topic {
+      CREATE MULTI LINK links := (.<topic[IS default::Link]);
+  };
+  CREATE TYPE default::Note {
+      CREATE REQUIRED LINK topic: default::Topic;
+      CREATE REQUIRED PROPERTY content: std::str;
+      CREATE REQUIRED PROPERTY public: std::bool;
       CREATE PROPERTY url: std::str;
   };
-  CREATE TYPE default::Topic {
-      CREATE MULTI LINK links: default::Link;
-      CREATE MULTI LINK notes: default::Note;
-      CREATE REQUIRED PROPERTY name: std::str;
-      CREATE REQUIRED PROPERTY content: std::str;
+  ALTER TYPE default::Topic {
+      CREATE MULTI LINK notes := (.<topic[IS default::Note]);
   };
   CREATE TYPE default::User {
       CREATE REQUIRED PROPERTY email: std::str;

--- a/grafbase/db/sync/sync.ts
+++ b/grafbase/db/sync/sync.ts
@@ -5,7 +5,7 @@ import e from "../dbschema/edgeql-js"
 import { getTopic, getTopicCount, getTopics } from "../topic"
 
 async function main() {
-  // await resetDb()
+  await resetDb()
   // seed()
   const userId = await getUserIdByName("Nikita")
   await forceWikiSync(userId)
@@ -21,7 +21,7 @@ main().catch((err) => {
 })
 
 async function seed() {
-  addUser({ name: "Nikita", email: "nikita@learn-anything.xyz" })
+  return addUser({ name: "Nikita", email: "nikita@learn-anything.xyz" })
 }
 
 async function clearTable(table: any) {

--- a/grafbase/db/sync/wiki.ts
+++ b/grafbase/db/sync/wiki.ts
@@ -2,6 +2,7 @@ import * as fs from "fs"
 import { readFile } from "fs/promises"
 import * as path from "path"
 import { dirname } from "path"
+import { URL } from "node:url";
 import { Link, Note, RelatedLink, addTopic } from "../topic"
 
 export async function syncWiki() {}
@@ -9,10 +10,9 @@ export async function syncWiki() {}
 // overwrite topics on server with local files
 export async function forceWikiSync(userId: string) {
   let fileIgnoreList = ["readme.md"]
-  const wikiPath = "/Users/nikiv/src/docs/wiki/docs"
+  const wikiPath = new URL("../../../src/docs", import.meta.url).pathname;
   const files = await markdownFilePaths(wikiPath, fileIgnoreList)
   if (files.length > 0) {
-    let testFile = "/Users/nikiv/Desktop/file.md"
     await mdFileIntoTopic(files[0], userId, wikiPath)
     // await mdFileIntoTopic(testFile, userId, wikiPath)
     // for (const file of files) {
@@ -275,11 +275,10 @@ async function mdFileIntoTopic(
     {
       name: topicName,
       content: content,
-      parentTopic: parentTopic,
-      // @ts-ignore
-      notes,
-      // @ts-ignore
-      links,
+      parentTopic: parentTopic ?? null,
+      public: false,
+      notes: notes.map((note) => ({ ...note, public: false })),
+      links: links.map((link) => ({ ...link, public: false })),
     },
     userId
   )

--- a/grafbase/db/topic.ts
+++ b/grafbase/db/topic.ts
@@ -53,28 +53,32 @@ export async function addTopic(topic: Topic, userId: string) {
         public: params.topic.public,
       })
 
-      return e.with([newTopic], e.for(e.json_array_unpack(params.notes), (note) =>
-        e.insert(e.Note, {
-          content: e.cast(e.str, e.json_get(note, "content")),
-          url: e.cast(e.str, e.json_get(note, "url")),
-          public: e.cast(e.bool, e.json_get(note, "public")),
-          topic: e.assert_exists(e.select(newTopic, () => ({ id: true }))),
-        })
-      ))
-
-      // const links = e.with([newTopic], e.for(e.json_array_unpack(params.links), (link) =>
-      //   e.insert(e.Link, {
-      //     title: e.cast(e.str, e.json_get(link, "title")),
-      //     url: e.cast(e.str, e.json_get(link, "url")),
-      //     public: e.cast(e.bool, e.json_get(link, "public")),
-      //     topic: e.assert_exists(e.select(e.Topic, () => ({ filter_single: { id: newTopic.id } }))),
-      //   })
-      // ))
-
-      // return e.with(
-      //   [newTopic],
-      //   e.select(newTopic, () => ({ id: true }))
-      // )
+      return e.with(
+        [newTopic],
+        e.for(e.json_array_unpack(params.notes), (note) =>
+          e.op(
+            e.insert(e.Note, {
+              content: e.cast(e.str, e.json_get(note, "content")),
+              url: e.cast(e.str, e.json_get(note, "url")),
+              public: e.cast(e.bool, e.json_get(note, "public")),
+              topic: e.assert_exists(e.select(newTopic, () => ({ id: true }))),
+            }),
+            "union",
+            e.for(e.json_array_unpack(params.links), (link) =>
+              e.insert(e.Link, {
+                title: e.cast(e.str, e.json_get(link, "title")),
+                url: e.cast(e.str, e.json_get(link, "url")),
+                public: e.cast(e.bool, e.json_get(link, "public")),
+                topic: e.assert_exists(
+                  e.select(newTopic, () => ({
+                    filter_single: { id: newTopic.id },
+                  }))
+                ),
+              })
+            )
+          )
+        )
+      )
     }
   )
   console.log("addTopic", query.toEdgeQL())

--- a/grafbase/db/topic.ts
+++ b/grafbase/db/topic.ts
@@ -56,7 +56,7 @@ export async function addTopic(topic: Topic, userId: string) {
           links: e.for(e.json_array_unpack(params.links), (link) =>
             e.insert(e.Link, {
               title: e.cast(e.str, e.json_get(link, "title")),
-              url: e.cast(e.str, e.json_get(link, "url"))
+              url: e.cast(e.str, e.json_get(link, "url")),
             })
           ),
         })

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "postcss": "^8.4.24",
     "solid-start-node": "^0.2.26",
     "tailwindcss": "^3.3.2",
+    "tsx": "^3.12.7",
     "typescript": "^5.1.6",
     "vite": "^4.3.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@hono/node-server':
     specifier: ^1.0.2
@@ -73,6 +69,9 @@ devDependencies:
   tailwindcss:
     specifier: ^3.3.2
     version: 3.3.2
+  tsx:
+    specifier: ^3.12.7
+    version: 3.12.7
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
@@ -1274,6 +1273,27 @@ packages:
     dependencies:
       chokidar: 3.5.3
       edgedb: 1.3.2
+    dev: true
+
+  /@esbuild-kit/cjs-loader@2.4.2:
+    resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.6.2
+    dev: true
+
+  /@esbuild-kit/core-utils@3.1.0:
+    resolution: {integrity: sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==}
+    dependencies:
+      esbuild: 0.17.19
+      source-map-support: 0.5.21
+    dev: true
+
+  /@esbuild-kit/esm-loader@2.5.5:
+    resolution: {integrity: sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.6.2
     dev: true
 
   /@esbuild/android-arm64@0.17.19:
@@ -2576,6 +2596,12 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  /get-tsconfig@4.6.2:
+    resolution: {integrity: sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3684,6 +3710,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
@@ -4152,6 +4182,17 @@ packages:
   /tslib@2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
 
+  /tsx@3.12.7:
+    resolution: {integrity: sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==}
+    hasBin: true
+    dependencies:
+      '@esbuild-kit/cjs-loader': 2.4.2
+      '@esbuild-kit/core-utils': 3.1.0
+      '@esbuild-kit/esm-loader': 2.5.5
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /type-fest@3.12.0:
     resolution: {integrity: sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==}
     engines: {node: '>=14.16'}
@@ -4493,3 +4534,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/docs/physics/0001.md
+++ b/src/docs/physics/0001.md
@@ -1,0 +1,9 @@
+# Classical mechanics
+
+## Notes
+
+How classical!
+
+## Links
+
+- [Structure and Interpretation of Classical Mechanics (2015)](https://mitpress.mit.edu/sites/default/files/titles/content/sicm_edition_2/toc.html) ([HN](https://news.ycombinator.com/item?id=19765019))


### PR DESCRIPTION
I haven't actually _run_ this query, but did fix the type errors and simplified turning optional `.notes` in to a valid JSON (in other words `null` since `undefined` is not valid JSON syntax).

If this works at runtime, I'll follow up with a version that uses `e.params` and cleans up some of this inline casting.